### PR TITLE
Fixed dry-run option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ const argv = require("yargs")
   .describe("dry-run", "Only outputs the proposed sort to the terminal")
   .option("dry-run", {
     alias: "d",
+    type: "boolean",
     default: false
   })
   .describe("indent", "Indentation width to use (in spaces)")


### PR DESCRIPTION
## Overview

Even if you use the `--dry-run` option, the input file will be overwritten.

```bash
# Nothing is displayed on standard output.
$ yml-sorter --dry-run -i index.yaml

# Sorted yaml data is output to standard output.
$ yml-sorter --dry-run true -i index.yaml
x: 1
z: 2
```

It is different from the usage example described in README.md, so it has been fixed.

```bash
$ yml-sorter --dry-run -i index.yaml
x: 1
z: 2
```
