### PR TITLE
chore: 🤖 .coderabbit.yaml を本格運用向けに拡充

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,18 +37,31 @@ reviews:
       - main
 
   path_instructions:
-    - path: "**/*.{js,mjs,cjs}"
+    - path: "{**/*.{js,mjs,cjs,ts,tsx},package.json}"
       instructions: |
-        Node.js / JavaScript コードとしてレビューしてください:
+        Node.js / JavaScript / TypeScript コードとしてレビューしてください:
         - 外部入力をそのまま `eval` / `Function` / `child_process.exec` へ流していないか。
         - 例外を握り潰さず、ログ／終了コードが妥当に扱われているか。
         - 依存パッケージのバージョン整合・既知脆弱性の混入が無いか。
+        - `package.json` の場合は依存関係の追加・変更・削除が意図的かを確認する。
     - path: ".github/workflows/**"
       instructions: |
         GitHub Actions ワークフローとしてレビューしてください:
         - シークレットの露出 (echo / set-output 経由のリーク) が無いか。
         - 外部 action は SHA pin されているか。
         - permissions: が最小権限になっているか。
+    - path: "**/Dockerfile*"
+      instructions: |
+        Dockerfile としてレビューしてください:
+        - 秘密情報（API キー等）が ENV または COPY でイメージ層に混入していないか。
+        - ベースイメージのタグが固定（latest 以外）されているか。
+        - 不要なパッケージやキャッシュが最終イメージに残っていないか。
+    - path: "**/*.{sh,bash}"
+      instructions: |
+        Shell スクリプトとしてレビューしてください:
+        - 外部入力をそのまま eval やコマンド置換に渡していないか。
+        - パス・ファイル名にスペースが含まれる場合のクォートが適切か。
+        - エラーハンドリング（set -e / set -u 等）が適切か。
 
   # 生成物 / 依存物などはレビュー対象から除外する。
   # ロックファイルは推移的依存の脆弱性診断に必要なため除外しない。

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,80 @@
-language: "ja"
+# CodeRabbit configuration
+# https://docs.coderabbit.ai/reference/configuration
+
+language: 'ja-JP'
+early_access: false
+enable_free_tier: true
+
 reviews:
-  summary:
-    poem: false
+  # YAML ファイルを並び替える Node.js CLI を OSS として公開しているリポジトリのため、利用者環境への影響を取りこぼしたくない。
+  # "assertive" で検出感度を高めに保ち、ノイズが過剰になった場合は "chill" に戻すことも検討する。
+  profile: 'assertive'
+
+  # PR 全体に対する指針。path_instructions に "**/*" を入れるとファイル毎に
+  # 繰り返し適用されてノイズが増えるため、広範な指示は instructions に集約する。
+  instructions: |
+    変更がプロジェクト全体に与える影響や、アーキテクチャの観点など、広いスコープからコードレビューを行ってください。必ず日本語でコメントしてください。
+    OSS として配布される Docker イメージ／CLI ツールのリポジトリであることを考慮し、以下の観点を強調し、重要視して必ずレビューに盛り込んでください:
+    - 認証情報、API キー、トークン、内部 URL などの秘密情報がコード・ログ・イメージ層に混入していないこと。
+    - 任意コード実行・コマンドインジェクション・パストラバーサルなど、利用者環境を危険にさらす脆弱性が無いこと。
+    - 入力検証（引数 / 標準入力 / 環境変数）が抜けていないこと。
+
+  # CodeRabbit を bot reviewer として動作させる。問題なしと判断した PR に対して
+  # Approve ステータスを返す。個人運営での self-merge 運用 (PR 作成者は自分の
+  # PR を承認できない GitHub 仕様) を補助する目的で有効化。Approve は最終判断
+  # ではなく補助。
+  request_changes_workflow: true
+
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+
+  path_instructions:
+    - path: '**/*.{js,mjs,cjs}'
+      instructions: |
+        Node.js / JavaScript コードとしてレビューしてください:
+        - 外部入力をそのまま `eval` / `Function` / `child_process.exec` へ流していないか。
+        - 例外を握り潰さず、ログ／終了コードが妥当に扱われているか。
+        - 依存パッケージのバージョン整合・既知脆弱性の混入が無いか。
+    - path: '.github/workflows/**'
+      instructions: |
+        GitHub Actions ワークフローとしてレビューしてください:
+        - シークレットの露出 (echo / set-output 経由のリーク) が無いか。
+        - 外部 action は SHA pin されているか。
+        - permissions: が最小権限になっているか。
+
+  # 生成物 / 依存物 / ロックファイルなどはレビュー対象から除外する。
+  path_filters:
+    - '!**/dist/**'
+    - '!**/build/**'
+    - '!**/coverage/**'
+    - '!**/node_modules/**'
+    - '!**/.wrangler/**'
+    - '!**/.turbo/**'
+    - '!**/.next/**'
+    - '!infra/cdktf.out/**'
+    - '!infra/.gen/**'
+    - '!**/bun.lock'
+    - '!**/package-lock.json'
+    - '!**/yarn.lock'
+    - '!**/pnpm-lock.yaml'
+    - '!**/*.min.js'
+    - '!**/*.min.css'
+    - '!**/*.map'
+    - '!**/*.snap'
+    - '!**/*.tsbuildinfo'
+
+  abort_on_close: true
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  opt_out: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,14 +1,14 @@
 # CodeRabbit configuration
 # https://docs.coderabbit.ai/reference/configuration
 
-language: 'ja-JP'
+language: "ja-JP"
 early_access: false
 enable_free_tier: true
 
 reviews:
   # YAML ファイルを並び替える Node.js CLI を OSS として公開しているリポジトリのため、利用者環境への影響を取りこぼしたくない。
   # "assertive" で検出感度を高めに保ち、ノイズが過剰になった場合は "chill" に戻すことも検討する。
-  profile: 'assertive'
+  profile: "assertive"
 
   # PR 全体に対する指針。path_instructions に "**/*" を入れるとファイル毎に
   # 繰り返し適用されてノイズが増えるため、広範な指示は instructions に集約する。
@@ -37,39 +37,36 @@ reviews:
       - main
 
   path_instructions:
-    - path: '**/*.{js,mjs,cjs}'
+    - path: "**/*.{js,mjs,cjs}"
       instructions: |
         Node.js / JavaScript コードとしてレビューしてください:
         - 外部入力をそのまま `eval` / `Function` / `child_process.exec` へ流していないか。
         - 例外を握り潰さず、ログ／終了コードが妥当に扱われているか。
         - 依存パッケージのバージョン整合・既知脆弱性の混入が無いか。
-    - path: '.github/workflows/**'
+    - path: ".github/workflows/**"
       instructions: |
         GitHub Actions ワークフローとしてレビューしてください:
         - シークレットの露出 (echo / set-output 経由のリーク) が無いか。
         - 外部 action は SHA pin されているか。
         - permissions: が最小権限になっているか。
 
-  # 生成物 / 依存物 / ロックファイルなどはレビュー対象から除外する。
+  # 生成物 / 依存物などはレビュー対象から除外する。
+  # ロックファイルは推移的依存の脆弱性診断に必要なため除外しない。
   path_filters:
-    - '!**/dist/**'
-    - '!**/build/**'
-    - '!**/coverage/**'
-    - '!**/node_modules/**'
-    - '!**/.wrangler/**'
-    - '!**/.turbo/**'
-    - '!**/.next/**'
-    - '!infra/cdktf.out/**'
-    - '!infra/.gen/**'
-    - '!**/bun.lock'
-    - '!**/package-lock.json'
-    - '!**/yarn.lock'
-    - '!**/pnpm-lock.yaml'
-    - '!**/*.min.js'
-    - '!**/*.min.css'
-    - '!**/*.map'
-    - '!**/*.snap'
-    - '!**/*.tsbuildinfo'
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/coverage/**"
+    - "!**/node_modules/**"
+    - "!**/.wrangler/**"
+    - "!**/.turbo/**"
+    - "!**/.next/**"
+    - "!infra/cdktf.out/**"
+    - "!infra/.gen/**"
+    - "!**/*.min.js"
+    - "!**/*.min.css"
+    - "!**/*.map"
+    - "!**/*.snap"
+    - "!**/*.tsbuildinfo"
 
   abort_on_close: true
 


### PR DESCRIPTION
## Summary

- CodeRabbit のレビュー指針 (`instructions`) を本リポジトリの性質に合わせて拡充
- `request_changes_workflow: true` を有効化し、問題なしと判断された PR に対する bot Approve を有効化（self-merge 運用の補助）
- `profile: 'assertive'` で検出感度を高めに固定
- `path_instructions` をリポジトリのスタックに合わせて整理（Dockerfile / Shell / Web / その他言語ごとの観点）
- `path_filters` で生成物・ロックファイル等のノイズを除外
- monopo / hyakuninissyu / toique と同じ運用ポリシーに揃え、個人運営リポジトリ間の設定差異を解消

## Test plan

- [ ] CodeRabbit が本 PR 自体に対して新ポリシーで自動レビューを行うこと
- [ ] 問題なしと判断された場合に CodeRabbit が Approve コメントを付与すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **チョア**
  * 言語設定を地域指定（ja→ja-JP）に更新しました。
  * レビュー運用設定を強化し、全体指針や表示オプションを追加しました。
  * 自動レビューを有効化し、ドラフト除外や対象ブランチ指定など挙動を明確化しました。
  * ファイル種別ごとのレビュー指針を追加し、生成物や依存物の除外ルールを導入しました。
  * クローズ時の中断、チャット自動返信、ナレッジベース設定を明示しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/yml-sorter/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->