### PR TITLE
ci: 🤖 Node.js CI ワークフローの actions を SHA pin して startup_failure を解消

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,6 +2,9 @@ name: Node.js CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,9 +14,11 @@ jobs:
         node-version: [22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
## Summary

- `.github/workflows/workflow.yml` の `Node.js CI` ワークフローが直近 main / PR で `startup_failure` を連発していた。原因はリポジトリ側の Actions ポリシーが SHA pin 必須になっているのに、本ワークフローだけ `actions/checkout@v4` / `actions/setup-node@v4` の tag 参照のままだったため。
- `actions/checkout` を他ワークフロー（actionlint / codeql / gitleaks / markdownlint）と同じ `a5ac7e51b41094c92402da3b24376905380afc29` (v4.1.6) に、`actions/setup-node` を `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0) に pin。
- ついでに最小権限原則に揃えて `permissions: contents: read` を明示し、checkout に `persist-credentials: false` を付与（他ワークフローと統一）。

## 原因の根拠

- 失敗 run: https://github.com/genzouw/yml-sorter/actions/runs/26264791593 (conclusion: `startup_failure`, jobs 0 件)
- リポジトリ管理側の Terraform (genzouw/genzouw.com `terraform/environments/github/main.tf` の `public_defaults`) で全 public リポジトリに次が適用されている:
  - `actions_allowed_actions = "selected"`
  - `actions_sha_pinning_required = true`
- 同ポリシーの下でも、他ワークフローは既に SHA pin 済みで `success` している (e.g. CodeQL run #26264791208 / Gitleaks run #26264791159)。本ワークフローのみ tag 参照が残っていた。

## Terraform 側の変更は不要

- 既存ポリシーは monopo / hyakuninissyu / toique と揃った妥当な運用ルールで、ここを緩めるのは方向違い。SHA pin が必須化されている前提でワークフロー側を合わせる方が筋が良い、と判断した。
- yml-sorter の `local.repositories` ブロックに個別の Actions ポリシー宣言（`manage_actions_permissions` 等）を足す必要もない — `public_defaults` 経由で既に意図通り効いている。

## Test plan

- [ ] 本 PR への push で `Node.js CI` ワークフローが `startup_failure` ではなく実際に build/test ジョブまで進むこと
- [ ] Node 22.x / 24.x の matrix 両方がグリーンになること
- [ ] `actionlint` ワークフローでも本ファイルの SHA pin が valid と判定されること